### PR TITLE
Support hidden and protected sheets

### DIFF
--- a/Sources/XLKitCore/CoreTypes.swift
+++ b/Sources/XLKitCore/CoreTypes.swift
@@ -109,12 +109,24 @@ public final class Workbook {
     // CSV/TSV operations are implemented in Workbook+API.swift to avoid circular dependencies
 }
 
+/// Visibility of a sheet in the workbook tab bar
+public enum SheetState: String {
+    /// Sheet is shown in the tab bar (default)
+    case visible
+    /// Sheet is hidden but can be unhidden by the user from the workbook UI
+    case hidden
+    /// Sheet is hidden and cannot be unhidden from the workbook UI; only programmatic access can restore it
+    case veryHidden
+}
+
 /// Represents a worksheet in an Excel workbook
 public final class Sheet: Equatable {
     /// The name of the sheet
     public let name: String
     /// The unique identifier of the sheet within the workbook
     public let id: Int
+    /// Visibility of the sheet in the workbook tab bar
+    public var state: SheetState = .visible
     /// Dictionary mapping cell coordinates to their values
     public var cells: [String: CellValue] = [:]
     /// Array of merged cell ranges

--- a/Sources/XLKitCore/CoreTypes.swift
+++ b/Sources/XLKitCore/CoreTypes.swift
@@ -119,6 +119,44 @@ public enum SheetState: String {
     case veryHidden
 }
 
+/// Per-sheet protection settings, mapped 1:1 to the `<sheetProtection>` XLSX element.
+///
+/// `nil` properties mean the attribute is omitted and the XLSX-defined default applies.
+/// Setting `Sheet.protection` to a non-nil value enables Excel's "Protect Sheet" behaviour
+/// on opening the file; cells with the default locked styling become read-only.
+public struct SheetProtection {
+    /// Whether protection is enforced on the sheet. Default: `true`.
+    public var sheet: Bool? = true
+    /// Legacy 16-bit password hash. Omit for unprotected dialog (still effective).
+    public var password: String?
+    /// Algorithm name for modern password hashing (e.g. `"SHA-512"`).
+    public var algorithmName: String?
+    /// Modern password hash, used with `algorithmName`, `saltValue`, `spinCount`.
+    public var hashValue: String?
+    /// Salt for modern password hash.
+    public var saltValue: String?
+    /// Iteration count for modern password hash.
+    public var spinCount: Int?
+    
+    public var objects: Bool?
+    public var scenarios: Bool?
+    public var formatCells: Bool?
+    public var formatColumns: Bool?
+    public var formatRows: Bool?
+    public var insertColumns: Bool?
+    public var insertRows: Bool?
+    public var insertHyperlinks: Bool?
+    public var deleteColumns: Bool?
+    public var deleteRows: Bool?
+    public var selectLockedCells: Bool?
+    public var selectUnlockedCells: Bool?
+    public var sort: Bool?
+    public var autoFilter: Bool?
+    public var pivotTables: Bool?
+    
+    public init() {}
+}
+
 /// Represents a worksheet in an Excel workbook
 public final class Sheet: Equatable {
     /// The name of the sheet
@@ -127,6 +165,8 @@ public final class Sheet: Equatable {
     public let id: Int
     /// Visibility of the sheet in the workbook tab bar
     public var state: SheetState = .visible
+    /// Protection settings for the sheet; `nil` means the sheet is not protected
+    public var protection: SheetProtection?
     /// Dictionary mapping cell coordinates to their values
     public var cells: [String: CellValue] = [:]
     /// Array of merged cell ranges

--- a/Sources/XLKitCore/CoreTypes.swift
+++ b/Sources/XLKitCore/CoreTypes.swift
@@ -124,6 +124,11 @@ public enum SheetState: String {
 /// `nil` properties mean the attribute is omitted and the XLSX-defined default applies.
 /// Setting `Sheet.protection` to a non-nil value enables Excel's "Protect Sheet" behaviour
 /// on opening the file; cells with the default locked styling become read-only.
+///
+/// Most boolean flags use inverted semantics — `true` means "this action is locked when
+/// the sheet is protected", not "this action is allowed." The XLSX-defined defaults
+/// already lock most actions down, so leaving a flag `nil` is usually correct unless you
+/// want to explicitly *allow* a specific action on the protected sheet.
 public struct SheetProtection {
     /// Whether protection is enforced on the sheet. Default: `true`.
     public var sheet: Bool? = true
@@ -138,20 +143,35 @@ public struct SheetProtection {
     /// Iteration count for modern password hash.
     public var spinCount: Int?
     
+    /// `true` locks drawing objects (shapes, charts, images) when the sheet is protected. XLSX default: `false`.
     public var objects: Bool?
+    /// `true` locks scenario edits when the sheet is protected. XLSX default: `false`.
     public var scenarios: Bool?
+    /// `true` locks cell formatting when the sheet is protected. XLSX default: `true`.
     public var formatCells: Bool?
+    /// `true` locks column formatting when the sheet is protected. XLSX default: `true`.
     public var formatColumns: Bool?
+    /// `true` locks row formatting when the sheet is protected. XLSX default: `true`.
     public var formatRows: Bool?
+    /// `true` locks column insertion when the sheet is protected. XLSX default: `true`.
     public var insertColumns: Bool?
+    /// `true` locks row insertion when the sheet is protected. XLSX default: `true`.
     public var insertRows: Bool?
+    /// `true` locks hyperlink insertion when the sheet is protected. XLSX default: `true`.
     public var insertHyperlinks: Bool?
+    /// `true` locks column deletion when the sheet is protected. XLSX default: `true`.
     public var deleteColumns: Bool?
+    /// `true` locks row deletion when the sheet is protected. XLSX default: `true`.
     public var deleteRows: Bool?
+    /// `true` blocks selection of locked cells when the sheet is protected. XLSX default: `false` — users can click locked cells but not edit them.
     public var selectLockedCells: Bool?
+    /// `true` blocks selection of unlocked cells when the sheet is protected. XLSX default: `false`.
     public var selectUnlockedCells: Bool?
+    /// `true` locks sort operations when the sheet is protected. XLSX default: `true`.
     public var sort: Bool?
+    /// `true` locks AutoFilter when the sheet is protected. XLSX default: `true`.
     public var autoFilter: Bool?
+    /// `true` locks PivotTable operations when the sheet is protected. XLSX default: `true`.
     public var pivotTables: Bool?
     
     public init() {}

--- a/Sources/XLKitXLSX/XLSXEngine.swift
+++ b/Sources/XLKitXLSX/XLSXEngine.swift
@@ -146,6 +146,37 @@ public struct XLSXEngine {
         return firstVisible > 0 ? " activeTab=\"\(firstVisible)\"" : ""
     }
     
+    /// Renders a `<sheetProtection>` element. Each attribute is emitted only when its property is non-nil, so the resulting element carries exactly the choices the caller made.
+    static func sheetProtectionXML(_ protection: SheetProtection) -> String {
+        var content = "<sheetProtection"
+        func append(_ name: String, _ value: Bool?) {
+            if let value { content += " \(name)=\"\(value ? 1 : 0)\"" }
+        }
+        append("sheet", protection.sheet)
+        if let password = protection.password { content += " password=\"\(password)\"" }
+        if let algorithmName = protection.algorithmName { content += " algorithmName=\"\(algorithmName)\"" }
+        if let hashValue = protection.hashValue { content += " hashValue=\"\(hashValue)\"" }
+        if let saltValue = protection.saltValue { content += " saltValue=\"\(saltValue)\"" }
+        if let spinCount = protection.spinCount { content += " spinCount=\"\(spinCount)\"" }
+        append("objects", protection.objects)
+        append("scenarios", protection.scenarios)
+        append("formatCells", protection.formatCells)
+        append("formatColumns", protection.formatColumns)
+        append("formatRows", protection.formatRows)
+        append("insertColumns", protection.insertColumns)
+        append("insertRows", protection.insertRows)
+        append("insertHyperlinks", protection.insertHyperlinks)
+        append("deleteColumns", protection.deleteColumns)
+        append("deleteRows", protection.deleteRows)
+        append("selectLockedCells", protection.selectLockedCells)
+        append("selectUnlockedCells", protection.selectUnlockedCells)
+        append("sort", protection.sort)
+        append("autoFilter", protection.autoFilter)
+        append("pivotTables", protection.pivotTables)
+        content += "/>"
+        return content
+    }
+    
     private static func generateStylesAndStrings(xlDir: URL, workbook: Workbook) throws -> ([String: Int], [String: Int]) {
         // Collect all unique formats from all sheets
         var uniqueFormats: [CellFormat] = []
@@ -512,6 +543,11 @@ public struct XLSXEngine {
         }
         
         content += "</sheetData>"
+        
+        // Add sheet protection if configured; must come after </sheetData> per ECMA-376
+        if let protection = sheet.protection {
+            content += sheetProtectionXML(protection)
+        }
         
         // Add merged cells if any
         let mergedRanges = sheet.getMergedRanges()

--- a/Sources/XLKitXLSX/XLSXEngine.swift
+++ b/Sources/XLKitXLSX/XLSXEngine.swift
@@ -119,12 +119,13 @@ public struct XLSXEngine {
         content += "<fileVersion appName=\"xl\" lastEdited=\"4\" lowestEdited=\"4\" rupBuild=\"4505\"/>"
         content += "<workbookPr defaultThemeVersion=\"124226\"/>"
         content += "<bookViews>"
-        content += "<workbookView xWindow=\"240\" yWindow=\"15\" windowWidth=\"16095\" windowHeight=\"9660\"/>"
+        let sheets = workbook.getSheets()
+        content += "<workbookView xWindow=\"240\" yWindow=\"15\" windowWidth=\"16095\" windowHeight=\"9660\"\(activeTabAttribute(for: sheets))/>"
         content += "</bookViews>"
         content += "<sheets>"
         
-        for sheet in workbook.getSheets() {
-            content += "<sheet name=\"\(CoreUtils.escapeXML(sheet.name))\" sheetId=\"\(sheet.id)\" r:id=\"rId\(sheet.id)\"/>"
+        for sheet in sheets {
+            content += "<sheet name=\"\(CoreUtils.escapeXML(sheet.name))\"\(sheetStateAttribute(sheet)) sheetId=\"\(sheet.id)\" r:id=\"rId\(sheet.id)\"/>"
         }
         
         content += "</sheets>"
@@ -132,6 +133,17 @@ public struct XLSXEngine {
         content += "</workbook>"
         
         return content
+    }
+    
+    /// Renders the optional `state` attribute for a `<sheet>` element; empty for visible sheets so existing files stay byte-identical.
+    static func sheetStateAttribute(_ sheet: Sheet) -> String {
+        sheet.state == .visible ? "" : " state=\"\(sheet.state.rawValue)\""
+    }
+    
+    /// Renders the optional `activeTab` attribute for `<workbookView>`; emitted only when the first visible sheet is not at index 0, otherwise Excel refuses to open a workbook whose default-active sheet is hidden.
+    static func activeTabAttribute(for sheets: [Sheet]) -> String {
+        let firstVisible = sheets.firstIndex { $0.state == .visible } ?? 0
+        return firstVisible > 0 ? " activeTab=\"\(firstVisible)\"" : ""
     }
     
     private static func generateStylesAndStrings(xlDir: URL, workbook: Workbook) throws -> ([String: Int], [String: Int]) {

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -19,12 +19,13 @@ This document provides an organized overview of all tests in the XLKit library, 
 - [Column Ordering Tests](#column-ordering-tests)
 - [Sheet Utility Tests](#sheet-utility-tests)
 - [Sheet State Tests](#sheet-state-tests)
+- [Sheet Protection Tests](#sheet-protection-tests)
 - [XLKitTestRunner](#xlkittestrunner)
 - [Test Execution & Validation](#test-execution--validation)
 - [Coverage & Quality Assurance](#coverage--quality-assurance)
 
 ## Test Overview
-- Total Tests: 66
+- Total Tests: 75
 - 100% coverage of public APIs
 - All generated files validated with CoreXLSX
 - Security features integrated throughout all tests
@@ -54,7 +55,8 @@ Tests/XLKitTests/
 ├── ImageTests.swift              # Image management (2 tests)
 ├── ColumnOrderingTests.swift     # Column ordering (2 tests)
 ├── SheetUtilityTests.swift       # Sheet utilities (6 tests)
-└── SheetStateTests.swift         # Sheet visibility state (7 tests)
+├── SheetStateTests.swift         # Sheet visibility state (7 tests)
+└── SheetProtectionTests.swift    # Sheet protection (9 tests)
 ```
 
 ### Shared Test Base (`XLKitTestBase.swift`)
@@ -249,6 +251,20 @@ All tests verify pixel-perfect scaling, Excel cell dimension matching, and zero 
 - `testActiveTabPointsAtFirstVisibleSheet()`: `activeTab` points at the first visible sheet when earlier sheets are hidden
 - `testSavingWorkbookWithHiddenSheetSucceeds()`: End-to-end save with a hidden tech sheet writes a valid file
 
+## Sheet Protection Tests
+
+**File**: `SheetProtectionTests.swift` (8 tests)
+
+- `testDefaultProtectionIsNil()`: New sheets have no protection by default
+- `testDefaultProtectionStructEnablesSheet()`: `SheetProtection()` defaults to `sheet: true`
+- `testMinimalProtectionXML()`: Default-constructed protection emits `<sheetProtection sheet="1"/>`
+- `testProtectionWithLegacyPassword()`: 16-bit `password` attribute is emitted alongside granular flags
+- `testProtectionWithModernHash()`: `algorithmName` / `hashValue` / `saltValue` / `spinCount` are emitted for PBKDF2-style protection
+- `testProtectionWithGranularPermissions()`: Boolean flags such as `formatCells`, `insertRows`, `sort` render as `1`/`0`
+- `testProtectionAllAttributesEmitted()`: All 21 attribute names appear in the XML when every flag is set; guards against typos in field names
+- `testProtectionOmittedWhenNotConfigured()`: Sheets without `protection` set produce no `<sheetProtection>` element
+- `testSavingWorkbookWithProtectedSheetSucceeds()`: End-to-end save with a protected sheet writes a valid file
+
 ## XLKitTestRunner
 
 A modular command-line tool for generating Excel files for testing and demonstration purposes.
@@ -357,7 +373,8 @@ swift run XLKitTestRunner help
 | Column Ordering    | ColumnOrderingTests.swift | 2        | 100%            |
 | Sheet Utilities    | SheetUtilityTests.swift | 6          | 100%            |
 | Sheet State        | SheetStateTests.swift   | 7          | 100%            |
-| **Total**          | **14 test files**      | **66**     | **100%**        |
+| Sheet Protection   | SheetProtectionTests.swift | 9       | 100%            |
+| **Total**          | **15 test files**      | **75**     | **100%**        |
 
 ### Quality Standards
 - All generated files pass CoreXLSX validation

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -18,12 +18,13 @@ This document provides an organized overview of all tests in the XLKit library, 
 - [Column & Row Sizing](#column--row-sizing)
 - [Column Ordering Tests](#column-ordering-tests)
 - [Sheet Utility Tests](#sheet-utility-tests)
+- [Sheet State Tests](#sheet-state-tests)
 - [XLKitTestRunner](#xlkittestrunner)
 - [Test Execution & Validation](#test-execution--validation)
 - [Coverage & Quality Assurance](#coverage--quality-assurance)
 
 ## Test Overview
-- Total Tests: 59
+- Total Tests: 66
 - 100% coverage of public APIs
 - All generated files validated with CoreXLSX
 - Security features integrated throughout all tests
@@ -52,7 +53,8 @@ Tests/XLKitTests/
 ├── FileOperationTests.swift      # File operations (2 tests)
 ├── ImageTests.swift              # Image management (2 tests)
 ├── ColumnOrderingTests.swift     # Column ordering (2 tests)
-└── SheetUtilityTests.swift      # Sheet utilities (6 tests)
+├── SheetUtilityTests.swift       # Sheet utilities (6 tests)
+└── SheetStateTests.swift         # Sheet visibility state (7 tests)
 ```
 
 ### Shared Test Base (`XLKitTestBase.swift`)
@@ -235,6 +237,18 @@ All tests verify pixel-perfect scaling, Excel cell dimension matching, and zero 
 - `testSheetUtilityProperties()`: Sheet utility properties and cell counting
 - `testSheetConvenienceInitializer()`: Sheet convenience initializer with data
 
+## Sheet State Tests
+
+**File**: `SheetStateTests.swift` (7 tests)
+
+- `testDefaultStateIsVisible()`: New sheets default to `.visible`
+- `testVisibleSheetOmitsStateAttribute()`: Visible sheets emit no `state` attribute so existing files stay byte-identical
+- `testHiddenSheetEmitsStateAttribute()`: `.hidden` sheets emit `state="hidden"`
+- `testVeryHiddenSheetEmitsStateAttribute()`: `.veryHidden` sheets emit `state="veryHidden"`
+- `testActiveTabOmittedWhenFirstSheetVisible()`: No `activeTab` attribute when the first sheet is visible
+- `testActiveTabPointsAtFirstVisibleSheet()`: `activeTab` points at the first visible sheet when earlier sheets are hidden
+- `testSavingWorkbookWithHiddenSheetSucceeds()`: End-to-end save with a hidden tech sheet writes a valid file
+
 ## XLKitTestRunner
 
 A modular command-line tool for generating Excel files for testing and demonstration purposes.
@@ -342,7 +356,8 @@ swift run XLKitTestRunner help
 | CSV/TSV            | CSVTests.swift          | 12         | 100%            |
 | Column Ordering    | ColumnOrderingTests.swift | 2        | 100%            |
 | Sheet Utilities    | SheetUtilityTests.swift | 6          | 100%            |
-| **Total**          | **13 test files**      | **59**     | **100%**        |
+| Sheet State        | SheetStateTests.swift   | 7          | 100%            |
+| **Total**          | **14 test files**      | **66**     | **100%**        |
 
 ### Quality Standards
 - All generated files pass CoreXLSX validation

--- a/Tests/XLKitTests/SheetProtectionTests.swift
+++ b/Tests/XLKitTests/SheetProtectionTests.swift
@@ -1,0 +1,118 @@
+//
+//  SheetProtectionTests.swift
+//  XLKit • https://github.com/TheAcharya/XLKit
+//  © 2025 Vigneswaran Rajkumar • Licensed under MIT License
+//
+
+import XCTest
+@testable import XLKit
+@testable import XLKitXLSX
+
+@MainActor
+final class SheetProtectionTests: XLKitTestBase {
+    
+    func testDefaultProtectionIsNil() {
+        let sheet = Workbook().addSheet(name: "Sheet1")
+        XCTAssertNil(sheet.protection)
+    }
+    
+    func testDefaultProtectionStructEnablesSheet() {
+        let protection = SheetProtection()
+        XCTAssertEqual(protection.sheet, true)
+        XCTAssertNil(protection.formatCells)
+        XCTAssertNil(protection.password)
+    }
+    
+    func testMinimalProtectionXML() {
+        let protection = SheetProtection()
+        XCTAssertEqual(XLSXEngine.sheetProtectionXML(protection), "<sheetProtection sheet=\"1\"/>")
+    }
+    
+    func testProtectionWithLegacyPassword() {
+        var protection = SheetProtection()
+        protection.password = "CC3F"
+        protection.selectLockedCells = true
+        XCTAssertEqual(
+            XLSXEngine.sheetProtectionXML(protection),
+            "<sheetProtection sheet=\"1\" password=\"CC3F\" selectLockedCells=\"1\"/>"
+        )
+    }
+    
+    func testProtectionWithModernHash() {
+        var protection = SheetProtection()
+        protection.algorithmName = "SHA-512"
+        protection.hashValue = "abc=="
+        protection.saltValue = "def=="
+        protection.spinCount = 100_000
+        let xml = XLSXEngine.sheetProtectionXML(protection)
+        XCTAssertTrue(xml.contains("algorithmName=\"SHA-512\""))
+        XCTAssertTrue(xml.contains("hashValue=\"abc==\""))
+        XCTAssertTrue(xml.contains("saltValue=\"def==\""))
+        XCTAssertTrue(xml.contains("spinCount=\"100000\""))
+    }
+    
+    func testProtectionWithGranularPermissions() {
+        var protection = SheetProtection()
+        protection.formatCells = false
+        protection.insertRows = false
+        protection.sort = true
+        let xml = XLSXEngine.sheetProtectionXML(protection)
+        XCTAssertTrue(xml.contains("formatCells=\"0\""))
+        XCTAssertTrue(xml.contains("insertRows=\"0\""))
+        XCTAssertTrue(xml.contains("sort=\"1\""))
+    }
+    
+    func testProtectionOmittedWhenNotConfigured() {
+        let sheet = Workbook().addSheet(name: "Sheet1")
+        XCTAssertNil(sheet.protection)
+    }
+    
+    func testProtectionAllAttributesEmitted() {
+        var protection = SheetProtection()
+        protection.password = "CC3F"
+        protection.algorithmName = "SHA-512"
+        protection.hashValue = "h"
+        protection.saltValue = "s"
+        protection.spinCount = 1
+        protection.objects = true
+        protection.scenarios = true
+        protection.formatCells = true
+        protection.formatColumns = true
+        protection.formatRows = true
+        protection.insertColumns = true
+        protection.insertRows = true
+        protection.insertHyperlinks = true
+        protection.deleteColumns = true
+        protection.deleteRows = true
+        protection.selectLockedCells = true
+        protection.selectUnlockedCells = true
+        protection.sort = true
+        protection.autoFilter = true
+        protection.pivotTables = true
+        
+        let xml = XLSXEngine.sheetProtectionXML(protection)
+        let expectedAttributes = [
+            "sheet", "password", "algorithmName", "hashValue", "saltValue", "spinCount",
+            "objects", "scenarios",
+            "formatCells", "formatColumns", "formatRows",
+            "insertColumns", "insertRows", "insertHyperlinks",
+            "deleteColumns", "deleteRows",
+            "selectLockedCells", "selectUnlockedCells",
+            "sort", "autoFilter", "pivotTables",
+        ]
+        for name in expectedAttributes {
+            XCTAssertTrue(xml.contains("\(name)=\""), "Missing attribute \(name) in: \(xml)")
+        }
+    }
+    
+    func testSavingWorkbookWithProtectedSheetSucceeds() throws {
+        let workbook = Workbook()
+        _ = workbook.addSheet(name: "Main")
+        let tech = workbook.addSheet(name: "Strings")
+        tech.protection = SheetProtection()
+        let url = makeTempWorkbookURL(prefix: "protected_sheet")
+        defer { cleanupTempFile(at: url) }
+        try workbook.save(to: url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/Tests/XLKitTests/SheetStateTests.swift
+++ b/Tests/XLKitTests/SheetStateTests.swift
@@ -1,0 +1,65 @@
+//
+//  SheetStateTests.swift
+//  XLKit • https://github.com/TheAcharya/XLKit
+//  © 2025 Vigneswaran Rajkumar • Licensed under MIT License
+//
+
+import XCTest
+@testable import XLKit
+@testable import XLKitXLSX
+
+@MainActor
+final class SheetStateTests: XLKitTestBase {
+    
+    func testDefaultStateIsVisible() {
+        let workbook = Workbook()
+        let sheet = workbook.addSheet(name: "Sheet1")
+        XCTAssertEqual(sheet.state, .visible)
+    }
+    
+    func testVisibleSheetOmitsStateAttribute() {
+        let sheet = Workbook().addSheet(name: "Sheet1")
+        XCTAssertEqual(XLSXEngine.sheetStateAttribute(sheet), "")
+    }
+    
+    func testHiddenSheetEmitsStateAttribute() {
+        let sheet = Workbook().addSheet(name: "Strings")
+        sheet.state = .hidden
+        XCTAssertEqual(XLSXEngine.sheetStateAttribute(sheet), " state=\"hidden\"")
+    }
+    
+    func testVeryHiddenSheetEmitsStateAttribute() {
+        let sheet = Workbook().addSheet(name: "Secret")
+        sheet.state = .veryHidden
+        XCTAssertEqual(XLSXEngine.sheetStateAttribute(sheet), " state=\"veryHidden\"")
+    }
+    
+    func testActiveTabOmittedWhenFirstSheetVisible() {
+        let workbook = Workbook()
+        _ = workbook.addSheet(name: "Main")
+        let tech = workbook.addSheet(name: "Strings")
+        tech.state = .hidden
+        XCTAssertEqual(XLSXEngine.activeTabAttribute(for: workbook.getSheets()), "")
+    }
+    
+    func testActiveTabPointsAtFirstVisibleSheet() {
+        let workbook = Workbook()
+        let first = workbook.addSheet(name: "Hidden1")
+        let second = workbook.addSheet(name: "Hidden2")
+        _ = workbook.addSheet(name: "Visible")
+        first.state = .hidden
+        second.state = .hidden
+        XCTAssertEqual(XLSXEngine.activeTabAttribute(for: workbook.getSheets()), " activeTab=\"2\"")
+    }
+    
+    func testSavingWorkbookWithHiddenSheetSucceeds() throws {
+        let workbook = Workbook()
+        _ = workbook.addSheet(name: "Main")
+        let tech = workbook.addSheet(name: "Strings")
+        tech.state = .hidden
+        let url = makeTempWorkbookURL(prefix: "hidden_state")
+        defer { cleanupTempFile(at: url) }
+        try workbook.save(to: url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+}


### PR DESCRIPTION
Two additive APIs for marking sheets as auxiliary or read-only:

- **`Sheet.state`** (`.visible` / `.hidden` / `.veryHidden`) - emits the `state` attribute on `<sheet>` and adds `activeTab` to `<workbookView>` when the first sheet is hidden, so Excel doesn't refuse to open the file.
- **`Sheet.protection`** (`SheetProtection?`) — emits the `<sheetProtection>` element. Supports the legacy password, modern PBKDF2 hash quartet, and all ECMA-376 granular permission flags. Each flag is documented, with the spec's inverted-boolean semantics (`true` = locked, not allowed) called out in the struct's header.

Existing files stay byte-identical because visible/unprotected sheets emit no new XML. Covered by 15 new unit tests (75 total). XML emission helpers are factored as internal `static` methods mirroring the existing `formatToKey` pattern.

Excel, LibreOffice, and Google Sheets respect both features. Apple Numbers ignores them per its usual XLSX quirks.